### PR TITLE
Changed Steam download URLs to valid ones, and added more instructions for Ubuntu 20.10 users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Installation is very simple. Follow these steps to install SteamOS Ubuntu:
 `cd steamos-ubuntu`    
 `sudo ./install.sh`
 
+4. If the "STEAM needs to be online to update" error appears on startup, Press CTRL+ALT+F3 to enter a virtual terminal, and login with the account used before installation.
+
+5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
+
+6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:
+`sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`
+`steam` (Just until the point which the Steam login window appears, which afterwards is safe to close)
+`reboot-to-steamos-mode`
+
 ## Advanced Options
 The installation script has several options that you can specify upon installation
 in the form of environment variables. You can specify these options by prefixing
@@ -88,6 +97,10 @@ Affected games this script fixes include:
 
 To fix this, add `steamos-fg %command%` to the launch options for each game you 
 wish to use this script with.
+
+### How can I change the resolution and refresh rate used in SteamOS mode?
+
+After installation, follow [this guide](https://github.com/ValveSoftware/SteamOS/wiki/Custom-Resolutions-And-Refresh-Rates) for instructions on how to change the screen resolution and refresh rate. This can optionally be done in "Step 6" of the Installation guide before rebooting to SteamOS mode.
 
 ## Attributions
 * Alkazar for [steamos-fg](https://github.com/alkazar/steamos-fg)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Installation is very simple. Follow these steps to install SteamOS Ubuntu:
 
 4. If the "STEAM needs to be online to update" error appears on startup, Press CTRL+ALT+F3 to enter a virtual terminal, and login with the account used before installation.
 
-5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
+5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account (as this will be required to run any sudo commands), run `sudo usermod -aG sudo steam` to give the account elevated privileges, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
 
 6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:    
 `sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`    

--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ Installation is very simple. Follow these steps to install SteamOS Ubuntu:
 5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
 
 6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:
-
 `sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`
+`steam`
 
-`steam` (Just until the point which the Steam login window appears, which afterwards is safe to close)
-
+7. After Steam is finished updating (When the Steam login window appears), close Steam, and run this command to reboot into SteamOS mode:
 `reboot-to-steamos-mode`
 
 ## Advanced Options
@@ -103,7 +102,7 @@ wish to use this script with.
 
 ### How can I change the resolution and refresh rate used in SteamOS mode?
 
-After installation, follow [this guide](https://github.com/ValveSoftware/SteamOS/wiki/Custom-Resolutions-And-Refresh-Rates) for instructions on how to change the screen resolution and refresh rate. This can optionally be done in "Step 6" of the Installation guide before rebooting to SteamOS mode.
+After installation, follow [this guide](https://github.com/ValveSoftware/SteamOS/wiki/Custom-Resolutions-And-Refresh-Rates) for instructions on how to change the screen resolution and refresh rate. This can be done after "Step 6" of the Installation guide.
 
 ## Attributions
 * Alkazar for [steamos-fg](https://github.com/alkazar/steamos-fg)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installation is very simple. Follow these steps to install SteamOS Ubuntu:
 5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
 
 6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:    
-`sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`
+`sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`    
 `steam`
 
 7. After Steam is finished updating (When the Steam login window appears), close Steam, and run this command to reboot into SteamOS mode:    

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ Installation is very simple. Follow these steps to install SteamOS Ubuntu:
 5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
 
 6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:
+
 `sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`
+
 `steam` (Just until the point which the Steam login window appears, which afterwards is safe to close)
+
 `reboot-to-steamos-mode`
 
 ## Advanced Options

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Installation is very simple. Follow these steps to install SteamOS Ubuntu:
 
 5. Run the `sudo passwd steam` command and follow the instructions to change the password to the Steam user account, then run the `reboot-to-desktop-mode` command to reboot to the GNOME desktop environment.
 
-6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:
+6. When back in the GNOME desktop environment, press "CTRL+ALT+T" or open the Terminal, and run these commands in order:    
 `sudo mkdir -p ~/.steam/ubuntu12_32/steam-runtime`
 `steam`
 
-7. After Steam is finished updating (When the Steam login window appears), close Steam, and run this command to reboot into SteamOS mode:
+7. After Steam is finished updating (When the Steam login window appears), close Steam, and run this command to reboot into SteamOS mode:    
 `reboot-to-steamos-mode`
 
 ## Advanced Options

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ After installation, follow [this guide](https://github.com/ValveSoftware/SteamOS
 ## Attributions
 * Alkazar for [steamos-fg](https://github.com/alkazar/steamos-fg)
 * nickcj931 for the [Steam offline error fix](https://github.com/ShadowApex/steamos-ubuntu/issues/6#issuecomment-498036893)
+* gamer-os for [Steam-Compositor-Plus](https://github.com/gamer-os/steamos-compositor-plus)
 
 ## Legal
 The Steam logo and Ubuntu logo are registered trademarks of Valve Corporation

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ After installation, follow [this guide](https://github.com/ValveSoftware/SteamOS
 
 ## Attributions
 * Alkazar for [steamos-fg](https://github.com/alkazar/steamos-fg)
+* nickcj931 for the [Steam offline error fix](https://github.com/ShadowApex/steamos-ubuntu/issues/6#issuecomment-498036893)
 
 ## Legal
 The Steam logo and Ubuntu logo are registered trademarks of Valve Corporation

--- a/install.sh
+++ b/install.sh
@@ -47,9 +47,9 @@ fi
 # Download the packages we need. If we fail at downloading, stop the script.
 set -e
 echo "Downloading SteamOS packages..."
-wget "http://repo.steamstatic.com/steamos/pool/main/s/steamos-compositor/steamos-compositor_${STEAMOS_COMPOSITOR_VER}.deb"
-wget "http://repo.steamstatic.com/steamos/pool/main/s/steamos-modeswitch-inhibitor/steamos-modeswitch-inhibitor_${STEAMOS_MODESWITCH_VER}.deb"
-wget "http://repo.steamstatic.com/steamos/pool/main/p/plymouth-themes-steamos/plymouth-themes-steamos_${STEAMOS_PLYMOUTH_VER}.deb"
+wget "https://repo.steampowered.com/steamos/pool/main/s/steamos-compositor/steamos-compositor_${STEAMOS_COMPOSITOR_VER}.deb"
+wget "https://repo.steampowered.com/steamos/pool/main/s/steamos-modeswitch-inhibitor/steamos-modeswitch-inhibitor_${STEAMOS_MODESWITCH_VER}.deb"
+wget "https://repo.steampowered.com/steamos/pool/main/p/plymouth-themes-steamos/plymouth-themes-steamos_${STEAMOS_PLYMOUTH_VER}.deb"
 set +e
 
 # See if there is a 'steam' user account. If not, create it.

--- a/install.sh
+++ b/install.sh
@@ -188,6 +188,10 @@ update-grub
 echo "Configuring the default session..."
 cp ./conf/steam-session.conf "/var/lib/AccountsService/users/${STEAM_USER}"
 
+# Install SteamOS-Compositor-Plus, and replace the built-in Steam compositor with it.
+echo "Installing SteamOS-Compositor-Plus..."
+wget https://raw.githubusercontent.com/gamer-os/steamos-compositor/master/steamos-install.sh && sudo bash steamos-install.sh
+
 echo ""
 echo "Installation complete! Press ENTER to reboot or CTRL+C to exit"
 read -r


### PR DESCRIPTION
I was working on trying to get a SteamOS-like install set up on the latest version of Ubuntu, and I stumbled across a ton of different issues in regard to getting it working, so I wanted to update the shell script to not have any download issues, and I also wanted to give instructions on what I had to do to get it up and running with the newest version of Ubuntu.